### PR TITLE
Remove redundant print in generators.c example

### DIFF
--- a/examples/generator.c
+++ b/examples/generator.c
@@ -53,7 +53,9 @@ consumerA(caiotask_t *self) {
     CAIO_BEGIN(self);
     while (true) {
         AWAIT(self, generator, producerA, &foo, &value);
-        INFO("foo yields: %d", value);
+        if (!CAIO_HASERROR(self)) {
+            INFO("foo yields: %d", value);
+        }
 
         AWAIT(self, generator, producerA, &bar, &value);
         if (!CAIO_HASERROR(self)) {


### PR DESCRIPTION
This PR removes a redundant print in the generator example.

![Screenshot from 2023-12-30 11-04-00](https://github.com/pylover/caio/assets/42068956/e09a8dd0-69cc-4d73-a11d-9d97fea39dda)
